### PR TITLE
Add surround-with live template for translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Added surround-with live template for translations (`<%t Key 'Text' %>`)
 
 ### Changed
 

--- a/src/main/resources/liveTemplates/Silverstripe.xml
+++ b/src/main/resources/liveTemplates/Silverstripe.xml
@@ -94,4 +94,11 @@
             <option name="Silverstripe" value="true" />
         </context>
     </template>
+    <template name="t" value="&#60;&#37;t $translationKey$ &#39;$SELECTION$&#39; &#37;&#62;" description="Surround with translation" toReformat="false" toShortenFQNames="true">
+        <variable name="translationKey" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="Silverstripe" value="true" />
+            <option name="SilverstripeHTML" value="true" />
+        </context>
+    </template>
 </templateSet>


### PR DESCRIPTION
## Summary

- Adds a `t` surround template to `liveTemplates/Silverstripe.xml`
- Highlight text, press ⌥⌘J, select `t` → produces `<%t TranslationKey 'Highlighted text' %>` with cursor on the key
- Available in both `Silverstripe` and `SilverstripeHTML` contexts since translations appear inline in HTML text

## Test plan

- [ ] Open a `.ss` file in the sandbox IDE (`./gradlew runIde`)
- [ ] Highlight some text, press ⌥⌘J and confirm `t` appears in the surround menu
- [ ] Select it and verify the output is `<%t <cursor> 'Highlighted text' %>`
- [ ] Confirm the same works when the selection is inside an HTML context (not just a block-level context)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)